### PR TITLE
fixup for 'Common: Changed how length is printed in Packet::str()'

### DIFF
--- a/src/inet/common/packet/Packet.cc
+++ b/src/inet/common/packet/Packet.cc
@@ -283,11 +283,11 @@ const Ptr<Chunk> Packet::removeAll()
     return makeExclusivelyOwnedMutableChunk(oldContent);
 }
 
-//(inet::Packet)UdpBasicAppData-0 (5000 bytes)
+//(inet::Packet)UdpBasicAppData-0 (5000 bytes) [content]
 std::string Packet::str() const
 {
     std::ostringstream out;
-    out << "(" << getClassName() << ")" << getName() << " (" << getTotalLength() << ") [" << content->str() << "]";
+    out << "(" << getClassName() << ")" << getName() << " (" << getDataLength() << ") [" << content->str() << "]";
     return out.str();
 }
 


### PR DESCRIPTION
The getTotalLength() returns the total length with popped head/trail parts