### PR TITLE
PacketFilterBase: Added missing Enter_Method which caused an exceptio…

### DIFF
--- a/src/inet/queueing/base/PacketFilterBase.cc
+++ b/src/inet/queueing/base/PacketFilterBase.cc
@@ -173,6 +173,7 @@ void PacketFilterBase::handlePushPacketProcessed(Packet *packet, cGate *gate, bo
 
 bool PacketFilterBase::canPullSomePacket(cGate *gate) const
 {
+    Enter_Method("canPullSomePacket");
     auto providerGate = inputGate->getPathStartGate();
     while (true) {
         auto packet = provider->canPullPacket(providerGate);


### PR DESCRIPTION
…n to be raised when the packet is deleted.

This happened with the latest OMNeT++ which checks for ownership before deletion.